### PR TITLE
support HTTP Basic Authentication

### DIFF
--- a/odm/src/com/nowsci/odm/CommonUtilities.java
+++ b/odm/src/com/nowsci/odm/CommonUtilities.java
@@ -27,6 +27,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+import android.util.Base64;
 
 public final class CommonUtilities extends Activity {
 
@@ -181,6 +182,14 @@ public final class CommonUtilities extends Activity {
 		return html;
 	}
 
+        static void setBasicAuthentication(HttpURLConnection conn, String url) {
+		String userInfo = url.getUserInfo();
+		if (userInfo != null && userInfo.length() > 0) {
+			String authString = Base64.encodeToString(userInfo.getBytes(), Base64.DEFAULT);
+			conn.setRequestProperty("Authorization", "Basic " + authString);
+		}
+	}
+
 	static String validPost(Map<String, String> params, byte[] bytes, URL url) throws IOException {
 		String html = "";
 		HostnameVerifier hostnameVerifier = org.apache.http.conn.ssl.SSLSocketFactory.STRICT_HOSTNAME_VERIFIER;
@@ -193,6 +202,7 @@ public final class CommonUtilities extends Activity {
 			conn.setUseCaches(false);
 			conn.setFixedLengthStreamingMode(bytes.length);
 			conn.setRequestMethod("POST");
+			setBasicAuthentication(conn, url);
 			conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8");
 			// post the request
 			OutputStream out = conn.getOutputStream();
@@ -261,6 +271,7 @@ public final class CommonUtilities extends Activity {
 			conn.setDoOutput(true);
 			conn.setUseCaches(false);
 			conn.setFixedLengthStreamingMode(bytes.length);
+			setBasicAuthentication(conn, url);
 			conn.setRequestMethod("POST");
 			conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8");
 			// post the request


### PR DESCRIPTION
I'd like to be able to put ODM behind HTTP Basic Authentication, so that I don't have to worry about whether anyone else might try to tinker with it.  Here's a pull request that might actually accomplish this.

To use: specify a username and password in the API url, for example https://user:password@yourhost.com/path/to/odm/

This is completely untested code.  I don't even know how to build it!  I pieced it together from a couple of tutorials I found, and I'm pretty rusty at Java.  So maybe this should be considered a feature request, with some of the legwork done already, and maybe it'll even work as written :)  I hope you like it!

Keep up the good work, and thanks a ton for open sourcing ODM.
